### PR TITLE
Create a shared instance of SAMHUDView and more…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.DS_Store

--- a/SAMHUDView/SAMHUDView.h
+++ b/SAMHUDView/SAMHUDView.h
@@ -17,9 +17,13 @@
 @property (nonatomic, strong) UIImage *completeImage;
 @property (nonatomic, strong) UIImage *failImage;
 
++ (id)sharedHUD;
+
 - (id)initWithTitle:(NSString *)aTitle;
 - (id)initWithTitle:(NSString *)aTitle loading:(BOOL)isLoading;
 
+- (void)showWithTitle:(NSString *)aTitle;
+- (void)showWithTitle:(NSString *)aTitle loading:(BOOL)isLoading;
 - (void)show;
 - (void)dismiss;
 - (void)dismissAnimated:(BOOL)animated;

--- a/SAMHUDView/SAMHUDView.m
+++ b/SAMHUDView/SAMHUDView.m
@@ -125,11 +125,26 @@ static CGFloat kIndicatorSize = 40.0f;
 		
 		NSString *dingbat = self.successful ? @"✔" : @"✘";
 		UIFont *dingbatFont = [UIFont systemFontOfSize:60.0f];
+		
+#if __IPHONE_OS_VERSION_MIN_REQUIRED >= 70000
+		CGSize dingbatSize = [dingbat sizeWithAttributes:@{NSFontAttributeName : dingbatFont}];
+#else
 		CGSize dingbatSize = [dingbat sizeWithFont:dingbatFont];
+#endif
+		
 		CGRect dingbatRect = CGRectMake(roundf((self.hudSize.width - dingbatSize.width) / 2.0f),
 										roundf((self.hudSize.height - dingbatSize.height) / 2.0f),
 										dingbatSize.width, dingbatSize.height);
+		
+#if __IPHONE_OS_VERSION_MIN_REQUIRED >= 70000
+		NSMutableParagraphStyle *style = [[NSMutableParagraphStyle alloc] init];
+		[style setAlignment:NSTextAlignmentCenter];
+		[style setLineBreakMode:NSLineBreakByClipping];
+		
+		[dingbat drawInRect:dingbatRect withAttributes:@{NSFontAttributeName : dingbatFont, NSParagraphStyleAttributeName : style}];
+#else
 		[dingbat drawInRect:dingbatRect withFont:dingbatFont lineBreakMode:NSLineBreakByClipping alignment:NSTextAlignmentCenter];
+#endif
 	}
 }
 
@@ -142,7 +157,17 @@ static CGFloat kIndicatorSize = 40.0f;
 	if (self.textLabel.hidden) {
 		self.textLabel.frame = CGRectZero;
 	} else {
+#if __IPHONE_OS_VERSION_MIN_REQUIRED >= 70000
+		NSMutableParagraphStyle *style = [[NSMutableParagraphStyle alloc] init];
+		[style setLineBreakMode:self.textLabel.lineBreakMode];
+		
+		CGSize textSize = [self.textLabel.text boundingRectWithSize:CGSizeMake(self.bounds.size.width, CGFLOAT_MAX)
+															options:NSStringDrawingUsesLineFragmentOrigin
+														 attributes:@{NSFontAttributeName : self.textLabel.font, NSParagraphStyleAttributeName : style}
+															context:nil].size;
+#else
 		CGSize textSize = [self.textLabel.text sizeWithFont:self.textLabel.font constrainedToSize:CGSizeMake(self.bounds.size.width, CGFLOAT_MAX) lineBreakMode:self.textLabel.lineBreakMode];
+#endif
 		self.textLabel.frame = CGRectMake(0.0f, roundf(self.hudSize.height - textSize.height - 10.0f), self.hudSize.width, textSize.height);
 	}
 }

--- a/SAMHUDView/SAMHUDView.m
+++ b/SAMHUDView/SAMHUDView.m
@@ -11,7 +11,7 @@
 
 #import <QuartzCore/QuartzCore.h>
 
-static CGFloat kIndicatorSize = 40.0;
+static CGFloat kIndicatorSize = 40.0f;
 
 @interface SAMHUDView ()
 @property (nonatomic, readonly) SAMHUDWindow *hudWindow;
@@ -35,9 +35,10 @@ static CGFloat kIndicatorSize = 40.0;
 @synthesize failImage = _failImage;
 @synthesize keyWindow = _keyWindow;
 
+
 - (void)setLoading:(BOOL)isLoading {
 	_loading = isLoading;
-	self.activityIndicator.alpha = _loading ? 1.0 : 0.0;
+	self.activityIndicator.alpha = _loading ? 1.0f : 0.0f;
 	[self setNeedsDisplay];
 }
 
@@ -55,7 +56,7 @@ static CGFloat kIndicatorSize = 40.0;
 - (UIActivityIndicatorView *)activityIndicator {
 	if (!_activityIndicator) {
 		_activityIndicator = [[UIActivityIndicatorView alloc] initWithActivityIndicatorStyle:UIActivityIndicatorViewStyleWhiteLarge];
-		_activityIndicator.alpha = 0.0;
+		_activityIndicator.alpha = 0.0f;
 	}
 	return _activityIndicator;
 }
@@ -64,7 +65,7 @@ static CGFloat kIndicatorSize = 40.0;
 - (UILabel *)textLabel {
 	if (!_textLabel) {
 		_textLabel = [[UILabel alloc] init];
-		_textLabel.font = [UIFont boldSystemFontOfSize:14];
+		_textLabel.font = [UIFont boldSystemFontOfSize:14.0f];
 		_textLabel.backgroundColor = [UIColor clearColor];
 		_textLabel.textColor = [UIColor whiteColor];
 		_textLabel.shadowColor = [UIColor colorWithWhite:0.0f alpha:0.7f];
@@ -87,9 +88,8 @@ static CGFloat kIndicatorSize = 40.0;
 	return (self = [self initWithTitle:nil loading:YES]);
 }
 
-
 - (void)dealloc {
-    [self dismiss];
+	[self dismiss];
 }
 
 
@@ -102,18 +102,18 @@ static CGFloat kIndicatorSize = 40.0;
 
 - (void)drawRect:(CGRect)rect {
 	CGContextRef context = UIGraphicsGetCurrentContext();
-
+	
 	// Draw rounded rectangle
 	CGContextSetRGBFillColor(context, 0.0f, 0.0f, 0.0f, 0.5f);
 	CGRect rrect = CGRectMake(0.0f, 0.0f, self.hudSize.width, self.hudSize.height);
 	[[UIBezierPath bezierPathWithRoundedRect:rrect cornerRadius:14.0f] fill];
-
+	
 	// Image
 	if (self.loading == NO) {
 		[[UIColor whiteColor] set];
-
+		
 		UIImage *image = self.successful ? self.completeImage : self.failImage;
-
+		
 		if (image) {
 			CGSize imageSize = image.size;
 			CGRect imageRect = CGRectMake(roundf((self.hudSize.width - imageSize.width) / 2.0f),
@@ -122,7 +122,7 @@ static CGFloat kIndicatorSize = 40.0;
 			[image drawInRect:imageRect];
 			return;
 		}
-
+		
 		NSString *dingbat = self.successful ? @"✔" : @"✘";
 		UIFont *dingbatFont = [UIFont systemFontOfSize:60.0f];
 		CGSize dingbatSize = [dingbat sizeWithFont:dingbatFont];
@@ -136,9 +136,9 @@ static CGFloat kIndicatorSize = 40.0;
 
 - (void)layoutSubviews {
 	self.activityIndicator.frame = CGRectMake(roundf((self.hudSize.width - kIndicatorSize) / 2.0f),
-										  roundf((self.hudSize.height - kIndicatorSize) / 2.0f),
-										  kIndicatorSize, kIndicatorSize);
-
+											  roundf((self.hudSize.height - kIndicatorSize) / 2.0f),
+											  kIndicatorSize, kIndicatorSize);
+	
 	if (self.textLabel.hidden) {
 		self.textLabel.frame = CGRectZero;
 	} else {
@@ -158,24 +158,24 @@ static CGFloat kIndicatorSize = 40.0;
 - (id)initWithTitle:(NSString *)aTitle loading:(BOOL)isLoading {
 	if ((self = [super initWithFrame:CGRectZero])) {
 		self.backgroundColor = [UIColor clearColor];
-
+		
 		self.hudSize = CGSizeMake(172.0f, 172.0f);
-
+		
 		// Activity indicator
 		[self.activityIndicator startAnimating];
 		[self addSubview:self.activityIndicator];
-
+		
 		// Text Label
 		self.textLabel.text = aTitle ? aTitle : NSLocalizedString(@"Loading…", nil);
 		[self addSubview:self.textLabel];
-
+		
 		// Loading
 		self.loading = isLoading;
-
+		
 		// Images
 		self.completeImage = [UIImage imageNamed:@"SAMHUDView-Check"];
 		self.failImage = [UIImage imageNamed:@"SAMHUDView-X"];
-
+		
 		// Orientation
 		[self setTransformForCurrentOrientation:NO];
 	}
@@ -186,47 +186,47 @@ static CGFloat kIndicatorSize = 40.0;
 - (void)show {
 	id<UIApplicationDelegate> delegate = [[UIApplication sharedApplication] delegate];
 	if ([delegate respondsToSelector:@selector(window)]) {
-        self.keyWindow = [delegate performSelector:@selector(window)];
+		self.keyWindow = [delegate performSelector:@selector(window)];
 	} else {
 		// Unable to get main window from app delegate
 		self.keyWindow = [[UIApplication sharedApplication] keyWindow];
 	}
-
+	
 	self.hudWindow.alpha = 0.0f;
 	self.alpha = 0.0f;
 	[self.hudWindow addSubview:self];
 	[self.hudWindow makeKeyAndVisible];
-
+	
 	[UIView beginAnimations:@"SAMHUDViewFadeInWindow" context:nil];
 	self.hudWindow.alpha = 1.0f;
 	[UIView commitAnimations];
-
+	
 	CGSize windowSize = self.hudWindow.frame.size;
 	CGRect contentFrame = CGRectMake(roundf((windowSize.width - self.hudSize.width) / 2.0f),
 									 roundf((windowSize.height - self.hudSize.height) / 2.0f) + 10.0f,
 									 self.hudSize.width, self.hudSize.height);
-
-
-    static CGFloat const offset = 20.0f;
-    if (UIInterfaceOrientationIsPortrait([UIApplication sharedApplication].statusBarOrientation)) {
+	
+	
+	static CGFloat const offset = 20.0f;
+	if (UIInterfaceOrientationIsPortrait([UIApplication sharedApplication].statusBarOrientation)) {
 		contentFrame.origin.y += offset;
-    } else {
-        contentFrame.origin.x += offset;
-    }
+	} else {
+		contentFrame.origin.x += offset;
+	}
 	self.frame = contentFrame;
-
+	
 	[UIView beginAnimations:@"SAMHUDViewFadeInContentAlpha" context:nil];
 	[UIView setAnimationDelay:0.1];
 	[UIView setAnimationDuration:0.2];
 	self.alpha = 1.0f;
 	[UIView commitAnimations];
-
+	
 	[UIView beginAnimations:@"SAMHUDViewFadeInContentFrame" context:nil];
 	[UIView setAnimationDelay:0.1];
 	[UIView setAnimationDuration:0.3];
 	self.frame = contentFrame;
 	[UIView commitAnimations];
-
+	
 	[[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(deviceOrientationChanged:) name:UIDeviceOrientationDidChangeNotification object:nil];
 }
 
@@ -296,29 +296,29 @@ static CGFloat kIndicatorSize = 40.0;
 	if (!self.superview) {
 		return;
 	}
-
+	
 	[UIView beginAnimations:@"SAMHUDViewFadeOutContentFrame" context:nil];
 	[UIView setAnimationDuration:0.2];
 	CGRect contentFrame = self.frame;
-    CGFloat offset = 20.0f;
-    if (UIInterfaceOrientationIsPortrait([UIApplication sharedApplication].statusBarOrientation)) {
+	CGFloat offset = 20.0f;
+	if (UIInterfaceOrientationIsPortrait([UIApplication sharedApplication].statusBarOrientation)) {
 		contentFrame.origin.y += offset;
-    } else {
+	} else {
 		contentFrame.origin.x += offset;
-    }
+	}
 	self.frame = contentFrame;
 	[UIView commitAnimations];
-
+	
 	[UIView beginAnimations:@"SAMHUDViewFadeOutContentAlpha" context:nil];
 	[UIView setAnimationDelay:0.1];
 	[UIView setAnimationDuration:0.2];
 	self.alpha = 0.0f;
 	[UIView commitAnimations];
-
+	
 	[UIView beginAnimations:@"SAMHUDViewFadeOutWindow" context:nil];
 	self.hudWindow.alpha = 0.0f;
 	[UIView commitAnimations];
-
+	
 	if (animated) {
 		double delayInSeconds = 0.3;
 		dispatch_time_t popTime = dispatch_time(DISPATCH_TIME_NOW, (int64_t)(delayInSeconds * NSEC_PER_SEC));
@@ -340,41 +340,41 @@ static CGFloat kIndicatorSize = 40.0;
 			// Zero
 			break;
 		}
-
+			
 		case UIInterfaceOrientationLandscapeLeft: {
 			rotation = -M_PI_2;
 			break;
 		}
-
+			
 		case UIInterfaceOrientationLandscapeRight: {
 			rotation = M_PI_2;
 			break;
 		}
-
+			
 		case UIInterfaceOrientationPortraitUpsideDown: {
 			rotation = M_PI;
 			break;
 		}
 	}
-
-    CGAffineTransform rotationTransform = CGAffineTransformMakeRotation(rotation);
-
+	
+	CGAffineTransform rotationTransform = CGAffineTransformMakeRotation(rotation);
+	
 	if (animated) {
 		[UIView beginAnimations:@"SAMHUDViewRotationTransform" context:nil];
 		[UIView setAnimationCurve:UIViewAnimationCurveEaseInOut];
 		[UIView setAnimationDuration:0.3];
 	}
-
+	
 	[self setTransform:rotationTransform];
-
-    if (animated) {
+	
+	if (animated) {
 		[UIView commitAnimations];
 	}
 }
 
 
 - (void)deviceOrientationChanged:(NSNotification *)notification {
-    [self setTransformForCurrentOrientation:YES];
+	[self setTransformForCurrentOrientation:YES];
 	[self setNeedsDisplay];
 }
 
@@ -382,11 +382,11 @@ static CGFloat kIndicatorSize = 40.0;
 - (void)removeWindow {
 	[self removeFromSuperview];
 	[self.hudWindow resignKeyWindow];
-
+	
 	// Return focus to the main window
 	[self.keyWindow makeKeyWindow];
 	self.keyWindow = nil;
-
+	
 	[[NSNotificationCenter defaultCenter] removeObserver:self name:UIDeviceOrientationDidChangeNotification object:nil];
 }
 

--- a/SAMHUDView/SAMHUDView.m
+++ b/SAMHUDView/SAMHUDView.m
@@ -84,8 +84,15 @@ static CGFloat kIndicatorSize = 40.0f;
 
 #pragma mark - NSObject
 
-- (id)init {
-	return (self = [self initWithTitle:nil loading:YES]);
++ (id)sharedHUD {
+	static id sharedInstance = nil;
+	static dispatch_once_t onceToken;
+	
+	dispatch_once(&onceToken, ^{
+		sharedInstance = [[self alloc] initWithTitle:nil loading:YES];
+	});
+	
+	return sharedInstance;
 }
 
 - (void)dealloc {
@@ -94,11 +101,6 @@ static CGFloat kIndicatorSize = 40.0f;
 
 
 #pragma mark - UIView
-
-- (id)initWithFrame:(CGRect)frame {
-	return (self = [self initWithTitle:nil loading:YES]);
-}
-
 
 - (void)drawRect:(CGRect)rect {
 	CGContextRef context = UIGraphicsGetCurrentContext();
@@ -205,6 +207,18 @@ static CGFloat kIndicatorSize = 40.0f;
 		[self setTransformForCurrentOrientation:NO];
 	}
 	return self;
+}
+
+
+- (void)showWithTitle:(NSString *)aTitle {
+	[self showWithTitle:aTitle loading:YES];
+}
+
+
+- (void)showWithTitle:(NSString *)aTitle loading:(BOOL)isLoading {
+	self.textLabel.text = aTitle ? aTitle : NSLocalizedString(@"Loading…", nil);
+	self.loading = isLoading;
+	[self show];
 }
 
 

--- a/SAMHUDView/SAMHUDWindow.m
+++ b/SAMHUDView/SAMHUDWindow.m
@@ -54,8 +54,8 @@ static SAMHUDWindow *kHUDWindow = nil;
 	CGContextRef context = UIGraphicsGetCurrentContext();
 	NSArray *colors = @[(id)[UIColor colorWithWhite:0.0f alpha:0.1f].CGColor, (id)[UIColor colorWithWhite:0.0f alpha:0.5f].CGColor];
 	CGGradientRef gradient = CGGradientCreateWithColors(CGColorGetColorSpace((__bridge CGColorRef)colors[0]), (__bridge CFArrayRef)colors, NULL);
-    CGPoint centerPoint  = CGPointMake(self.bounds.size.width / 2.0 , self.bounds.size.height / 2.0);
-    CGContextDrawRadialGradient(context, gradient, centerPoint, 0.0f, centerPoint, fmaxf(self.bounds.size.width, self.bounds.size.height) / 2.0f, kCGGradientDrawsAfterEndLocation);
+	CGPoint centerPoint  = CGPointMake(self.bounds.size.width / 2.0f, self.bounds.size.height / 2.0f);
+	CGContextDrawRadialGradient(context, gradient, centerPoint, 0.0f, centerPoint, fmaxf(self.bounds.size.width, self.bounds.size.height) / 2.0f, kCGGradientDrawsAfterEndLocation);
 	CGGradientRelease(gradient);
 }
 


### PR DESCRIPTION
Adds the ability to create a shared instance of SAMHUDView. So, now you could just do `[[SAMHUDView sharedHUD] showWithTitle:@"Loading…"];` and not worry about allocating an instance, and it'll work fine across view controllers and stuff.

Also fixes some deprecated methods in projects compiled only for iOS 7 and above, while still maintaining backwards compatibility for older SDKs.

I should go to sleep now. Goodnight...or good morning...whatever.
